### PR TITLE
exit with non-zero status on error

### DIFF
--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -95,7 +95,7 @@ jobs:
               --payload $(echo "{\"input\": \"${{ matrix.input }}\"}" | base64) \
               --output json out 
             if grep -q "Error" out; then
-              exit1
+              exit 1
             fi
       - name: Destroy test function
         if: ${{ always() }}


### PR DESCRIPTION
The `exit1` command in the _Invoke test function_ step is malformed and results in a `command not found` error. 

While the step does error out, it actually exits with code 127 due to the syntax error.

![actions_deep_dive_test_function_exit](https://user-images.githubusercontent.com/18267047/163414759-79d14d72-d688-4d6b-9c5c-f7a94579ca40.png)
