### PR TITLE
exit with non-zero status on error

### DIFF
--- a/.github/workflows/action.yaml
+++ b/.github/workflows/action.yaml
@@ -95,7 +95,7 @@ jobs:
               --payload $(echo "{\"input\": \"${{ matrix.input }}\"}" | base64) \
               --output json out 
             if grep -q "Error" out; then
-              exit1
+              exit 1
             fi
       - name: Destroy test function
         if: ${{ always() }}


### PR DESCRIPTION
The `exit1` command in the _Invoke test function_ step is malformed and results in a `command not found` error.

This is a companion PR to https://github.com/linuxacademy/content-github-actions-deep-dive-lesson/pull/9 on the `lesson-test` branch.